### PR TITLE
Added test IMAP001 - Check status of IMAP services

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -89,6 +89,17 @@
 		<IfFailedComments></IfFailedComments>
 	</Test>
 
+    <Test>
+		<Id>IMAP001</Id>
+		<Category>IMAP</Category>
+		<Name>IMAP Service Status</Name>
+		<Description>Check the status of the IMAP services.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments></IfPassedComments>
+		<IfWarningComments></IfWarningComments>
+		<IfFailedComments></IfFailedComments>
+	</Test>
+
 	<Test>
 		<Id>DB001</Id>
 		<Category>Databases</Category>

--- a/Tests/IMAP001.ps1
+++ b/Tests/IMAP001.ps1
@@ -1,0 +1,56 @@
+Function Run-IMAP001()
+{
+    [CmdletBinding()]
+    param()
+
+    $TestID = "IMAP001"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    $IMAPServers = @($ExchangeServers | Where {$_.IsClientAccessServer -or $_.IsMailboxServer})
+
+    foreach ($Server in $IMAPServers)
+    {
+        Write-Verbose "Checking IMAP services for $($Server)"
+
+        try
+        {
+            #This test won't return StartupType. Need to replace with a WMI query once the WMI framework
+            #has been built into the ExchangeAnalyzer module.
+            $IMAPServices = @(Get-Service -ComputerName $Server MSExchangeIMAP* -ErrorAction STOP)
+            foreach ($IMAPService in $IMAPServices)
+            {
+                $tmpString = "$($Server): $($IMAPService.DisplayName) is $($IMAPService.Status)"
+                Write-Verbose $tmpString
+                $InfoList += $tmpString
+            }
+        }
+        catch
+        {
+            Write-Verbose "Unable to determine IMAP service status"
+            Write-Verbose $_.Exception.Message
+
+            $ErrorList += "$($Server) - unable to determine IMAP service status."
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-IMAP001
+


### PR DESCRIPTION
This test performs a simple service status check to add an Info item to the report, same as the POP service status check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exchangeanalyzer/exchangeanalyzer/156)
<!-- Reviewable:end -->
