### PR TITLE
Added some error handling for Get-ExARegistryValue

### DIFF
--- a/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
+++ b/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
@@ -443,7 +443,7 @@ Function Get-ExARegistryValue()
 
         $valueData = $null
         
-        Write-Error $_.Exception.Message
+        Write-Error "Unable to get registry value. $($_.Exception.Message)"
     }
 
     return $valueData

--- a/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
+++ b/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
@@ -441,7 +441,9 @@ Function Get-ExARegistryValue()
     {
         $remoteHive = $null
 
-        $valueData = "Unable to connect to registry."
+        $valueData = $null
+        
+        Write-Error "Unable to connect to registry."
     }
 
     return $valueData

--- a/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
+++ b/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
@@ -429,11 +429,20 @@ Function Get-ExARegistryValue()
         # Key doesn't exist
         # Value doesn't exist - default should work for us
 
-    $remoteHive = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey($Hive, $Host)
+    try
+    {
+        $remoteHive = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey($Hive, $Host)
 
-    $hKey = $remoteHive.OpenSubKey($Key, $false)
+        $hKey = $remoteHive.OpenSubKey($Key, $false)
 
-    $valueData = $hKey.GetValue($Value, $Default)
+        $valueData = $hKey.GetValue($Value, $Default)
+    }
+    catch
+    {
+        $remoteHive = $null
+
+        $valueData = "Unable to connect to registry."
+    }
 
     return $valueData
 }

--- a/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
+++ b/Modules/ExchangeAnalyzer/ExchangeAnalyzer.psm1
@@ -443,7 +443,7 @@ Function Get-ExARegistryValue()
 
         $valueData = $null
         
-        Write-Error "Unable to connect to registry."
+        Write-Error $_.Exception.Message
     }
 
     return $valueData


### PR DESCRIPTION
This change adds try/catch error handling to the function that is making
remote registry calls.

For servers that the script can't connect to, such as an Edge server or
an offline server, a terminating error was occurring previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exchangeanalyzer/exchangeanalyzer/159)
<!-- Reviewable:end -->
