### PR TITLE
Added IMAP protocol logging test

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -90,6 +90,17 @@
 	</Test>
 
 	<Test>
+		<Id>IMAP003</Id>
+		<Category>IMAP</Category>
+		<Name>IMAP Protocol Logging</Name>
+		<Description>Check that IMAP protocol logging is not enabled.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments>No IMAP services have protocol logging enabled.</IfPassedComments>
+		<IfWarningComments>One or more IMAP services has protocol logging enabled.</IfWarningComments>
+		<IfFailedComments></IfFailedComments>
+	</Test>
+
+	<Test>
 		<Id>DB001</Id>
 		<Category>Databases</Category>
 		<Name>Database Backups</Name>

--- a/Tests/IMAP003.ps1
+++ b/Tests/IMAP003.ps1
@@ -1,0 +1,57 @@
+Function Run-IMAP003()
+{
+    [CmdletBinding()]
+    param()
+
+    $TestID = "IMAP003"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    #Check IMAP settings for ProtocolLogEnabled configuration. Protocol logging for IMAP
+    #does not have age/retention settings, so it can grow to consume all available disk
+    #space on the server. Because external cleanup options are possible, eg running a
+    #script as a scheduled task, if IMAP protocol logging is enabled it is considered
+    #a warning not a fail.
+
+    foreach ($IMAPSetting in $AllIMAPSettings)
+    {
+        Write-Verbose "Checking IMAP protocol logging settings for $($IMAPSetting.Server)"
+        
+        switch ($IMAPSetting.ProtocolLogEnabled -eq $true)
+        {
+            $true {
+                $tmpString = "$($IMAPSetting.Server) has protocol logging enabled"
+                Write-Verbose $tmpString
+                $WarningList += $IMAPSetting.Server
+                }
+            $false {
+                $tmpString = "$($IMAPSetting.Server) has protocol logging disabled"
+                Write-Verbose $tmpString
+                $PassedList += $IMAPSetting.Server
+                }
+            default {
+                $ErrorList += "$($IMAPSetting.Server) protocol log setting could not be determined"
+                }
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-IMAP003
+


### PR DESCRIPTION
This test checks whether IMAP protocol logging has been enabled, and warns if it is.

This test has a dependency on the PR for IMAP002 which adds collection of IMAP settings from servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exchangeanalyzer/exchangeanalyzer/160)
<!-- Reviewable:end -->
