### PR TITLE
WSSRV007 Test - Windows Firewall startup mode check

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -143,14 +143,25 @@
 		<IfWarningComments>One or more Exchange servers are a virtual server.</IfWarningComments>
 	</Test>
 	
-  <Test>
+	<Test>
 		<Id>WSSRV001</Id>
 		<Category>Windows Server</Category>
 		<Name>Exchange Install Volume Free Disk Space</Name>
 		<Description>Check that the Exchange install volume has 30% or greater free disk space.</Description>
 		<IfInfoComments></IfInfoComments>
-        <IfPassedComments>All Exchange install volumes have greater than 30% free disk space.</IfPassedComments>
-       	<IfWarningComments>One or more Exchange install volumes has between 15% and 30% free disk space.</IfWarningComments>		
-       	<IfFailedComments>One or more Exchange install volumes has less than 15% free disk space.</IfFailedComments>        
+		<IfPassedComments>All Exchange install volumes have greater than 30% free disk space.</IfPassedComments>
+		<IfWarningComments>One or more Exchange install volumes has between 15% and 30% free disk space.</IfWarningComments>		
+		<IfFailedComments>One or more Exchange install volumes has less than 15% free disk space.</IfFailedComments>        
+	</Test>
+
+	<Test>
+		<Id>WSSRV007</Id>
+		<Category>Windows Server</Category>
+		<Name>Windows Firewall Service Startup Mode Check</Name>
+		<Description>Check to make sure the Windows Firewall service is set to Automatic startup.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments>The Windows Firewall service is set to Automatic startup.</IfPassedComments>
+		<IfWarningComments>A CIM or WMI connection to the server could not be made.</IfWarningComments>		
+		<IfFailedComments>The Windows Firewall service is set to a value other than Automatic startup.</IfFailedComments>        
 	</Test>
 </Tests>

--- a/Tests/WSSRV007.ps1
+++ b/Tests/WSSRV007.ps1
@@ -1,0 +1,76 @@
+#requires -Modules ExchangeAnalyzer
+
+#This function checks to see if the Windows Firewall Service is set to a value other than Automatic
+Function Run-WSSRV007()
+{
+
+   [CmdletBinding()]
+    param()
+
+    $TestID = "WSSRV007"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    foreach ($server in $exchangeservers) {
+        # Set Variables for the current loop
+        $name = $server.name
+        $ConnectionError = $false
+        $tryWMI = $false
+        $FirewallState = $null
+
+        try {
+            $FirewallState = (Get-CIMInstance -Class win32_service -filter "name = 'mpssvc'" -ComputerName $name -erroraction STOP).startmode
+        } catch {
+            $tryWMI = $true
+            Write-Verbose "$($TestID): Was not able to acquire information for $name via CIM"    
+        }
+        if ($tryWMI) {
+            try {
+                $FirewallState = (Get-WmiObject -Class win32_service -filter "name = 'mpssvc'" -ComputerName $name -erroraction STOP).startmode
+            } catch {
+                Write-Verbose "$($TestID): Was not able to acquire information for $name via WMI"    
+                $ConnectionError = $true
+            }
+        }
+
+        If ($ConnectionError -eq $false) {
+                       
+            # Validate if the firewall service is set to Automatic on the server
+            if ($FirewallState -eq "Auto") {
+
+                # The Windows Firewall service's startup mode is set to Automatic
+                write-verbose "The firewall service on $name is set to Automatic."
+                $PassedList += $($name)
+            } else {
+
+                # Fail the server for having the service startup mode set to anything but Automatic
+                write-verbose "The firewall service on $name is set to Manual or Disabled and should be set to Automatic."
+                $FailedList += $($name)
+            }
+        } else {
+
+            # Script failed to connect to the server and is added to the warning list
+            write-verbose "There was an issue connecting to the $name server. "
+            $WarningList += $($name)
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-WSSRV007

--- a/Tests/WSSRV007.ps1
+++ b/Tests/WSSRV007.ps1
@@ -18,22 +18,22 @@ Function Run-WSSRV007()
 
     foreach ($server in $exchangeservers) {
         # Set Variables for the current loop
-        $name = $server.name
+        $ServerName = $server.name
         $ConnectionError = $false
         $tryWMI = $false
         $FirewallState = $null
 
         try {
-            $FirewallState = (Get-CIMInstance -Class win32_service -filter "name = 'mpssvc'" -ComputerName $name -erroraction STOP).startmode
+            $FirewallState = (Get-CIMInstance -Class win32_service -filter "name = 'mpssvc'" -ComputerName $ServerName -erroraction STOP).startmode
         } catch {
             $tryWMI = $true
-            Write-Verbose "$($TestID): Was not able to acquire information for $name via CIM"    
+            Write-Verbose "$($TestID): Was not able to acquire information for $ServerName via CIM"    
         }
         if ($tryWMI) {
             try {
-                $FirewallState = (Get-WmiObject -Class win32_service -filter "name = 'mpssvc'" -ComputerName $name -erroraction STOP).startmode
+                $FirewallState = (Get-WmiObject -Class win32_service -filter "name = 'mpssvc'" -ComputerName $ServerName -erroraction STOP).startmode
             } catch {
-                Write-Verbose "$($TestID): Was not able to acquire information for $name via WMI"    
+                Write-Verbose "$($TestID): Was not able to acquire information for $ServerName via WMI"    
                 $ConnectionError = $true
             }
         }
@@ -44,19 +44,19 @@ Function Run-WSSRV007()
             if ($FirewallState -eq "Auto") {
 
                 # The Windows Firewall service's startup mode is set to Automatic
-                write-verbose "The firewall service on $name is set to Automatic."
-                $PassedList += $($name)
+                write-verbose "The firewall service on $ServerName is set to Automatic."
+                $PassedList += $($ServerName)
             } else {
 
                 # Fail the server for having the service startup mode set to anything but Automatic
-                write-verbose "The firewall service on $name is set to Manual or Disabled and should be set to Automatic."
-                $FailedList += $($name)
+                write-verbose "The firewall service on $ServerName is set to Manual or Disabled and should be set to Automatic."
+                $FailedList += $($ServerName)
             }
         } else {
 
             # Script failed to connect to the server and is added to the warning list
-            write-verbose "There was an issue connecting to the $name server. "
-            $WarningList += $($name)
+            write-verbose "There was an issue connecting to the $ServerName server. "
+            $WarningList += $($ServerName)
         }
     }
 


### PR DESCRIPTION
This test will check the Windows Firewall startup mode.  To pass the service must be set to Automatic.  Any other setting will cause the test
to fail.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exchangeanalyzer/exchangeanalyzer/163)

<!-- Reviewable:end -->
